### PR TITLE
Adjust GptConsulterController prompt response type

### DIFF
--- a/src/Controller/GptConsulterController.php
+++ b/src/Controller/GptConsulterController.php
@@ -4,20 +4,20 @@ namespace App\Controller;
 
 
 use App\Service\GptExceptionConsulter;
-use JetBrains\PhpStorm\NoReturn;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[AsController]
 class GptConsulterController extends AbstractController
 {
-    #[NoReturn] #[Route(path: 'prompt', name: 'prompt', methods: ['GET', 'POST'])]
-    public function prompt(GptExceptionConsulter $gptExceptionConsulter): string
+    #[Route(path: 'prompt', name: 'prompt', methods: ['GET', 'POST'])]
+    public function prompt(GptExceptionConsulter $gptExceptionConsulter): JsonResponse
     {
-        $result = $gptExceptionConsulter->generateComment('sdsd', 'sdsd');
-
-        return $this->json(['generated_text' => $result]);
+        return $this->json([
+            'generated_text' => $gptExceptionConsulter->generateComment('sdsd', 'sdsd'),
+        ]);
     }
 
 }


### PR DESCRIPTION
## Summary
- remove the NoReturn attribute from the prompt controller action
- type-hint the prompt action to return a JsonResponse
- return the json helper call directly to match the declared return type

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d767624eb0832299f8545d8a6deb73